### PR TITLE
All tests are passing in IE8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js: node
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://api.travis-ci.org/canjs/can-fixture.svg?branch=master)](https://travis-ci.org/canjs/can-fixture)
+[![npm version](https://badge.fury.io/js/can-fixture.svg)](http://badge.fury.io/js/can-fixture)
+
 # can-fixture
 
 

--- a/helpers/deparam.js
+++ b/helpers/deparam.js
@@ -1,3 +1,5 @@
+var helpers = require("can-set").helpers;
+
 var digitTest = /^\d+$/,
 	keyBreaker = /([^\[\]]+)|(\[\])/g,
 	paramTest = /([^?#]*)(#.*)?$/,
@@ -9,7 +11,7 @@ module.exports = function (params) {
 	var data = {}, pairs, lastPart;
 	if (params && paramTest.test(params)) {
 		pairs = params.split('&');
-		pairs.forEach(function (pair) {
+		helpers.each(pairs, function (pair) {
 			var parts = pair.split('='),
 				key = prep(parts.shift()),
 				value = prep(parts.join('=')),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "steal-qunit": "0.0.2",
     "testee": "^0.2.0",
     "steal-tools": "^0.12.0-pre.3",
-    "jquery": "^2.1.4"
+    "jquery": "^1.11.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Intercept AJAX requests and simulate responses.",
   "main": "fixture.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "testee --browsers firefox test/test.html"
   },
   "dependencies": {
     "can-set": "^0.3.0"
@@ -28,5 +28,12 @@
   "bugs": {
     "url": "https://github.com/canjs/can-fixture/issues"
   },
-  "homepage": "https://github.com/canjs/can-fixture"
+  "homepage": "https://github.com/canjs/can-fixture",
+  "system": {
+    "npmDependencies": [
+      "can-set",
+      "steal-qunit",
+      "jquery"
+    ]
+  }
 }

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -11,11 +11,11 @@ var errorCallback = function(xhr, status, error){
 
 	QUnit.module('can/util/fixture');
 	test('static fixtures', function () {
-		
+
 		stop();
 		fixture('GET something', __dirname+'/fixtures/test.json');
 		fixture('POST something', __dirname+'/fixtures/test.json');
-		
+
 		$.ajax({
 			url: 'something',
 			dataType: 'json'
@@ -33,7 +33,7 @@ var errorCallback = function(xhr, status, error){
 					},errorCallback);
 			}, errorCallback);
 	});
-	
+
 	test('templated static fixtures', function () {
 		stop();
 		fixture('GET some/{id}', __dirname+'/fixtures/stuff.{id}.json');
@@ -92,7 +92,7 @@ var errorCallback = function(xhr, status, error){
 					});
 			});
 	});
-	
+
 
 	test('fixture.store fixtures', function () {
 		stop();
@@ -108,7 +108,7 @@ var errorCallback = function(xhr, status, error){
 			}
 		});
 		fixture('things', store.findAll);
-		
+
 		$.ajax({
 			url: 'things',
 			dataType: 'json',
@@ -290,7 +290,7 @@ var errorCallback = function(xhr, status, error){
 					});
 			});
 	});
-	
+
 	test('fixture.store with can.Model', function () {
 		var store = fixture.store(100, function (i) {
 			return {
@@ -305,21 +305,21 @@ var errorCallback = function(xhr, status, error){
 				update: 'PUT /models/{id}',
 				destroy: 'DELETE /models/{id}'
 			}, {})*/;
-		
+
 		fixture('GET /models', store.getListData);
 		fixture('GET /models/{id}', store.getData);
 		fixture('POST /models', store.createData);
 		fixture('PUT /models/{id}', store.updateData);
 		fixture('DELETE /models/{id}', store.destroyData);
-		
+
 		stop();
 		function errorAndStart(e){
 			ok(false, "borked"+e);
 			debugger;
 			start();
 		}
-		
-		
+
+
 		var check100Updated = function(){
 			return $.ajax({
 				url: "/models/100",
@@ -328,14 +328,14 @@ var errorCallback = function(xhr, status, error){
 				equal(model.name, 'Updated test object', 'Successfully updated object');
 			});
 		};
-		
-		
+
+
 		$.ajax({
 			url: "/models",
 			dataType: 'json'
 		}).then(function (modelsData) {
 			var models = modelsData.data;
-				
+
 			equal(models.length, 100, 'Got 100 models for findAll with no parameters');
 			equal(models[95].name, 'Object 95', 'All models generated properly');
 			return $.ajax({
@@ -371,9 +371,9 @@ var errorCallback = function(xhr, status, error){
 											}
 										})
 										.then(function (model) {
-											
+
 											return check100Updated().then(function(){
-												
+
 												return $.ajax({
 														url: "/models/100",
 														dataType: 'json',
@@ -382,9 +382,9 @@ var errorCallback = function(xhr, status, error){
 													.then(function (deleted) {
 														start();
 													},errorAndStart);
-												
+
 											}, errorAndStart);
-											
+
 										},errorAndStart);
 								},errorAndStart);
 						},errorAndStart);
@@ -409,7 +409,7 @@ var errorCallback = function(xhr, status, error){
 			start();
 		});
 	});
-	
+
 	test('fixture.store returns 404 on update with a bad id (#803)', function () {
 		var store = fixture.store(5, function (i) {
 			return {
@@ -419,9 +419,9 @@ var errorCallback = function(xhr, status, error){
 		});
 
 		stop();
-		
+
 		fixture('POST /models/{id}', store.update);
-		
+
 		$.ajax({url: "/models/6", dataType: "json", data: {'jedan': 'dva'}, type: 'POST'})
 			.then(function(){},function (data) {
 				equal(data.statusText, 'error', 'Got an error');
@@ -429,7 +429,7 @@ var errorCallback = function(xhr, status, error){
 				start();
 			});
 	});
-	
+
 	test('fixture.store returns 404 on destroy with a bad id (#803)', function () {
 		var store = fixture.store(2, function (i) {
 			return {
@@ -439,7 +439,7 @@ var errorCallback = function(xhr, status, error){
 		});
 
 		stop();
-		
+
 		fixture('DELETE /models/{id}', store.destroy);
 
 		$.ajax({url: "/models/6", dataType: "json", type: 'DELETE'})
@@ -566,9 +566,9 @@ var errorCallback = function(xhr, status, error){
 			url: 'foo/5'
 		});
 	});
-	
+
 	test("create a store with array and comparison object",function(){
-		
+
 		var store = fixture.store([
 			{id: 1, modelId: 1, year: 2013, name: "2013 Mustang", thumb: "http://mustangsdaily.com/blog/wp-content/uploads/2012/07/01-2013-ford-mustang-gt-review-585x388.jpg"},
 			{id: 2, modelId: 1, year: 2014, name: "2014 Mustang", thumb: "http://mustangsdaily.com/blog/wp-content/uploads/2013/03/2014-roush-mustang.jpg"},
@@ -581,23 +581,23 @@ var errorCallback = function(xhr, status, error){
 		],{
 			year: function(a, b){
 				return a == b;
-				
+
 			},
 			modelId: function(a, b){
 				return a == b;
 			}
 		});
-		
-		
+
+
 		fixture('GET /presetStore', store.findAll);
 		stop();
 		$.ajax({ url: "/presetStore", method: "get", data: {year: 2013, modelId:1}, dataType: "json" }).then(function(response){
-			
+
 			equal(response.data[0].id, 1, "got the first item");
 			equal(response.data.length, 1, "only got one item");
 			start();
 		});
-		
+
 	});
 
 	test("store with objects allows .create, .update and .destroy (#1471)", 4, function(){
@@ -624,9 +624,9 @@ var errorCallback = function(xhr, status, error){
 		};
 
 		stop();
-		
+
 		// $.ajax({ url: "/presetStore", method: "get", data: {year: 2013, modelId:1}, dataType: "json" })
-		
+
 		findAll().then(function(carsData) {
 			equal(carsData.data.length, 8, 'Got all cars');
 			return $.ajax({ url: "/cars/"+carsData.data[1].id, method: "DELETE", dataType: "json" });
@@ -659,13 +659,13 @@ var errorCallback = function(xhr, status, error){
 
 
 	test("filtering works", function() {
-	
+
 		var store = fixture.store(
 			[	{ state : 'CA', name : 'Casadina' },
-				{ state : 'NT', name : 'Alberny' }], 
+				{ state : 'NT', name : 'Alberny' }],
 			// David, make sure this is here!
 			{});
-	
+
 		fixture({
 			'GET /api/cities' : store.findAll,
 		});
@@ -683,9 +683,9 @@ var errorCallback = function(xhr, status, error){
 			ok(false, ""+e);
 			start()
 		});
-		
+
 		function next(){
-	
+
 			var store =fixture.store([{
 				_id : 1,
 				name : 'Cheese City',
@@ -703,14 +703,14 @@ var errorCallback = function(xhr, status, error){
 					state : 'NT'
 				}
 			}],{
-				
+
 			});
-	
+
 			fixture({
 				'GET /restaurants' : store.findAll
-			}); 
+			});
 			$.getJSON('/api/restaurants?address[city]=Alberny').then(function(responseData){
-				
+
 				deepEqual(responseData, {
 					count: 1,
 					data: [{
@@ -724,7 +724,7 @@ var errorCallback = function(xhr, status, error){
 					}]
 				});
 				last();
-				
+
 			}, function(e){
 				ok(false);
 				debugger;
@@ -769,6 +769,6 @@ var errorCallback = function(xhr, status, error){
 			});
 			start();
 		}
-	}); 
+	});
 
-	
+

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -4,7 +4,6 @@ var set = require("can-set");
 var $ = require("jquery");
 
 var errorCallback = function(xhr, status, error){
-	debugger;
 	ok(false);
 	start();
 };
@@ -315,7 +314,6 @@ var errorCallback = function(xhr, status, error){
 		stop();
 		function errorAndStart(e){
 			ok(false, "borked"+e);
-			debugger;
 			start();
 		}
 


### PR DESCRIPTION
With this change now all tests are passing in IE8.

The biggest challenge for IE8 is that it doesn't support
Object.defineProperty. We use defineProperty to shim a few properties
onto our fake XMLHttpRequest object so that when a library (like jQuery)
    attempts to read the `readyState` property (for example) it gets the
    value from the real xhr object. Because this won't work in IE8 we
    had to use another method; we wait for the request to complete and
    then copy the real XHR values back over to our fake XHR instance,
    this way when code reads the value they are getting what was really
    on XHR.

Closes #1

<img width="1308" alt="screen shot 2015-10-08 at 8 51 46 am" src="https://cloud.githubusercontent.com/assets/361671/10367010/e992eb84-6d9b-11e5-826e-a55185d7d91d.png">
