### PR TITLE
Use setRequestHeader to set headers on original XHR

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -943,6 +943,27 @@ asyncTest("pass return value for fixture", function(){
 	xhr.send();
 });
 
+asyncTest("pass headers in fallthrough", function() {
+	var url = __dirname+'/fixtures/foobar.json';
+	var xhr = new XMLHttpRequest();
+	expect(2);
+
+	xhr.open("GET", url);
+	xhr.setRequestHeader("foo", "bar");
+	xhr.onreadystatechange = function(ev){
+		var originalXhr = ev.target;
+		if(originalXhr.readyState === 1) {
+			originalXhr.setRequestHeader = function(key, val) {
+				equal(key, "foo");
+				equal(val, "bar");
+			}
+		}
+		if(originalXhr.readyState === 4) {
+			start();
+		}
+	}
+	xhr.send();
+});
 
 test("set.Algebra CRUD works (#12)", 5, function(){
 

--- a/xhr.js
+++ b/xhr.js
@@ -239,6 +239,11 @@ assign(XMLHttpRequest.prototype,{
 			makeRequest = function(){
 				mockXHR._xhr = xhr;
 				xhr.open( xhr.type, xhr.url, xhr.async );
+				if(mockXHR._headers) {
+					Object.keys(mockXHR._headers).forEach(function(key) {
+						xhr.setRequestHeader(key, mockXHR._headers[key]);
+					});
+				}
 				return xhr.send(data);
 			};
 


### PR DESCRIPTION
 ...when passing through to a non-fixturized ajax call.

This prevents odd behavior on setting Content-Type and also doesn't eat custom headers when making AJAX calls.
