### PR TITLE
Fix arraybuffer errors

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,3 @@
-
 {
   "globals": {
     "steal": true,
@@ -20,8 +19,7 @@
     "stop": true,
 	"global": true
   },
-
-
+  "strict": false,
   "curly": true,
   "eqeqeq": true,
   "freeze": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "46.0"

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -5,6 +5,7 @@ var set = require("can-set");
 var $ = require("jquery");
 var each = require("can-util/js/each/each");
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
+var clone = require('steal-clone');
 
 var errorCallback = function(xhr, status, error){
 	ok(false);
@@ -1354,4 +1355,33 @@ asyncTest('onload should be triggered for HTTP error responses (#36)', function(
 
 	xhr.open('GET', '/onload');
 	xhr.send();
+});
+
+asyncTest('responseText & responseXML should not be set for arraybuffer types (#38)', function() {
+	Object.defineProperty(XMLHttpRequest.prototype, "responseText", {
+		get: function() { ok(false, 'should not get responseText'); },
+		set: function() { ok(false, 'should not set responseText'); }
+	});
+	Object.defineProperty(XMLHttpRequest.prototype, "responseXML", {
+		get: function() { ok(false, 'should not get responseXML'); },
+		set: function() { ok(false, 'should not set responseXML'); }
+	});
+
+	clone({})
+		.import('xhr')
+		.then(function () {
+			fixture('/onload', '/test/fixtures/foo.json');
+
+			var xhr = new XMLHttpRequest();
+
+			xhr.addEventListener('load', function() {
+				fixture('/onload', null);
+				ok(true, 'should not get or set responseText or responseXML');
+				start();
+			});
+
+			xhr.open('GET', '/onload');
+			xhr.responseType = 'arraybuffer';
+			xhr.send();
+		});
 });

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -5,7 +5,6 @@ var set = require("can-set");
 var $ = require("jquery");
 var each = require("can-util/js/each/each");
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
-var clone = require('steal-clone');
 
 var errorCallback = function(xhr, status, error){
 	ok(false);
@@ -1358,30 +1357,26 @@ asyncTest('onload should be triggered for HTTP error responses (#36)', function(
 });
 
 asyncTest('responseText & responseXML should not be set for arraybuffer types (#38)', function() {
-	Object.defineProperty(XMLHttpRequest.prototype, "responseText", {
-		get: function() { ok(false, 'should not get responseText'); },
-		set: function() { ok(false, 'should not set responseText'); }
+
+	fixture('/onload', '/test/fixtures/foo.json');
+
+	var oldError = window.onerror;
+
+	window.onerror = function (msg, url, line) {
+	    ok(false, 'There should not be an error');
+	    start();
+	}
+
+	var xhr = new XMLHttpRequest();
+
+	xhr.addEventListener('load', function() {
+		fixture('/onload', null);
+		window.onerror = oldError;
+		ok(true, 'Got here without an error');
+		start();
 	});
-	Object.defineProperty(XMLHttpRequest.prototype, "responseXML", {
-		get: function() { ok(false, 'should not get responseXML'); },
-		set: function() { ok(false, 'should not set responseXML'); }
-	});
 
-	clone({})
-		.import('xhr')
-		.then(function () {
-			fixture('/onload', '/test/fixtures/foo.json');
-
-			var xhr = new XMLHttpRequest();
-
-			xhr.addEventListener('load', function() {
-				fixture('/onload', null);
-				ok(true, 'should not get or set responseText or responseXML');
-				start();
-			});
-
-			xhr.open('GET', '/onload');
-			xhr.responseType = 'arraybuffer';
-			xhr.send();
-		});
+	xhr.responseType = 'arraybuffer';
+	xhr.open('GET', '/onload');
+	xhr.send();
 });

--- a/xhr.js
+++ b/xhr.js
@@ -64,11 +64,21 @@ var makeXHR = function(mockXHR){
 	// When the real XHR is called back, update all properties
 	// and call all callbacks on the mock XHR.
 	xhr.onreadystatechange = function(ev){
+		// If the XHRs responseType is not '' or 'text', browsers will throw an error
+		// when trying to access the `responseText` property so we have to ignore it
+		if(xhr.responseType === '' || xhr.responseType === 'text') {
+			delete propsToIgnore.responseText;
+			delete propsToIgnore.responseXML;
+		} else {
+			propsToIgnore.responseText = true;
+			propsToIgnore.responseXML = true;
+		}
 
 		// Copy back everything over because in IE8 defineProperty
 		// doesn't work, so we need to make our shim XHR have the same
 		// values as the real xhr.
-		assign(mockXHR, xhr,propsToIgnore);
+
+		assign(mockXHR, xhr, propsToIgnore);
 		if(mockXHR.onreadystatechange) {
 			mockXHR.onreadystatechange(ev);
 		}


### PR DESCRIPTION
This is a partial solution for #38 that makes sure that the `responseText` and `responseXML` properties are being ignored if the `responseType` is not `''` or `'text'`.

This is necessary when a Socket.io connection is being established since `can-fixture` throws an error trying to intercept those XHRs.
