### PR TITLE
Set response headers provided in fixture responses

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1424,3 +1424,20 @@ asyncTest('responseText & responseXML should not be set for arraybuffer types (#
 	xhr.open('GET', '/onload');
 	xhr.send();
 });
+
+asyncTest("response headers are set", function(){
+	fixture("GET /todos", function(request, response){
+		response(200, "{}", { foo: "bar"});
+	});
+
+	var xhr = new XMLHttpRequest();
+
+	xhr.addEventListener('load', function(){
+		var headers = xhr.getAllResponseHeaders();
+		ok(headers.foo === "bar", "header was set");
+		start();
+	});
+
+	xhr.open('GET', "/todos");
+	xhr.send();
+});

--- a/xhr.js
+++ b/xhr.js
@@ -221,6 +221,11 @@ assign(XMLHttpRequest.prototype,{
 				}
 
 
+
+				each(headers || {}, function(value, key){
+					mockXHR._headers[key] = value;
+				});
+
 				if(mockXHR.onreadystatechange) {
 					mockXHR.onreadystatechange({ target: mockXHR });
 				}


### PR DESCRIPTION
In the requestHandler signature `requestHandler(request, response(...)`
the `response` function can provide headers that are part of the
response. These should be set so that they can be accessed by
`xhr.getAllResponseHeaders()`, and this change makes that happen.

Fixes #680
