### PR TITLE
Making getAllResponseHeaders return a string

### DIFF
--- a/xhr.js
+++ b/xhr.js
@@ -118,7 +118,11 @@ GLOBAL.XMLHttpRequest = function(){
 	var headers = this._headers = {};
 	this._xhr = {
 		getAllResponseHeaders: function(){
-			return headers;
+			var ret = [];
+			each(headers, function(value, name) {
+				Array.prototype.push.apply(ret, [name, ': ', value, '\r\n']);
+			});
+			return ret.join('');
 		}
 	};
 	this.__events = {};


### PR DESCRIPTION
This PR makes the `getAllResponseHeaders` method match the behavior from the [spec](https://xhr.spec.whatwg.org/#the-getallresponseheaders%28%29-method). getAllResponseHeaders should return a string instead of an Object.

This was breaking in an app that was using [superagent](https://www.npmjs.com/package/superagent) to make requests.
