### PR TITLE
Prevent status and statusText from being accessed when readyState <= 1

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -867,6 +867,22 @@ asyncTest("doesn't break onreadystatechange (#3)", function () {
 	xhr.send();
 });
 
+asyncTest("doesn't copy status or statusText when readyState <= 1", function () {
+	var url = __dirname + '/fixtures/test.json';
+	var xhr = new XMLHttpRequest();
+
+	xhr.onreadystatechange = function () {
+		if (xhr.readyState === 1) {
+			ok(typeof xhr.status === 'undefined', "did not copy status");
+			ok(typeof xhr.statusText === 'undefined', "did not copy statusText");
+			start();
+		}
+	};
+
+	xhr.open('GET', url);
+	xhr.send();
+});
+
 QUnit.module("XHR Shim");
 
 test("Supports onload", function(){

--- a/xhr.js
+++ b/xhr.js
@@ -76,6 +76,16 @@ var makeXHR = function(mockXHR){
 			propsToIgnore.responseXML = true;
 		}
 
+		// If the XHRs readyState is not 2, 3 or 4 accessing status or statusText
+		// will throw an InvalidStateError in Webkit
+		if(xhr.readyState <= 1) {
+			propsToIgnore.status = true;
+			propsToIgnore.statusText = true;
+		} else {
+			delete propsToIgnore.status;
+			delete propsToIgnore.statusText;
+		}
+
 		// Copy back everything over because in IE8 defineProperty
 		// doesn't work, so we need to make our shim XHR have the same
 		// values as the real xhr.


### PR DESCRIPTION
This PR prevents the `status` and `statusText` properties from being copied in the `onreadystatechange` handler while `readyState` is `0` or `1`.

This prevents Webkit (notably Phantom) from throwing an `InvalidStateError`.
