### PR TITLE
Ie9 fixtures assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "jquery": "^3.1.1",
+    "jquery": "^2.2.4",
     "jshint": "^2.7.0",
     "steal": "^0.16.21",
     "steal-qunit": "^0.1.1",

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1480,12 +1480,14 @@ asyncTest('fixture with timeout aborts if xhr timeout less than delay', function
 
 	var xhr = new XMLHttpRequest();
 	xhr.open('GET', '/onload');
+	xhr.send();
+
 	setTimeout(function() {
 		xhr.abort();
 	}, 50);
-	xhr.send();
+	
 
-	xhr.addEventListener('error', function() {
+	xhr.addEventListener('abort', function() {
 		fixture('/onload', null);
 		ok(true, 'Got to the error handler');
 		equal(xhr.statusText, "aborted");
@@ -1517,13 +1519,14 @@ asyncTest('dynamic fixture with timeout does not run if xhr timeout less than de
 	}, 50);
 	xhr.send();
 
-	xhr.addEventListener('error', function() {
+	xhr.addEventListener('abort', function() {
 		fixture('/onload', null);
 		ok(true, 'Got to the error handler');
-		equal(xhr.statusText, "aborted");
-		equal(xhr.status, "0");
+		equal(xhr.statusText, '');
+		equal(xhr.status, 0);
 		start();
 	});
+
 	fixture.delay = delay;
 });
 
@@ -1650,8 +1653,8 @@ test("abort() sets readyState correctly", function(){
 	xhr.addEventListener('abort', function() {
 		fixture('/foo', null);
 		ok(true, 'Got to the error handler');
-		equal(xhr.status, "0");
-		equal(xhr.statusText, "");
+		equal(xhr.status, 0);
+		equal(xhr.statusText, '');
 
 		setTimeout(function(){
 			equal(xhr.readyState, 0);

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1490,8 +1490,8 @@ asyncTest('fixture with timeout aborts if xhr timeout less than delay', function
 	xhr.addEventListener('abort', function() {
 		fixture('/onload', null);
 		ok(true, 'Got to the error handler');
-		equal(xhr.statusText, "aborted");
-		equal(xhr.status, "0");
+		equal(xhr.statusText, '');
+		equal(xhr.status, 0);
 		start();
 	});
 
@@ -1646,6 +1646,10 @@ test("set.Algebra stores provide a count (#58)", function(){
 
 test("abort() sets readyState correctly", function(){
 	stop();
+
+	fixture('/foo', function() {
+		return {};
+	});
 
 	var xhr = new XMLHttpRequest();
 	xhr.open('GET', '/foo');

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -867,22 +867,6 @@ asyncTest("doesn't break onreadystatechange (#3)", function () {
 	xhr.send();
 });
 
-asyncTest("doesn't copy status or statusText when readyState <= 1", function () {
-	var url = __dirname + '/fixtures/test.json';
-	var xhr = new XMLHttpRequest();
-
-	xhr.onreadystatechange = function () {
-		if (xhr.readyState === 1) {
-			ok(typeof xhr.status === 'undefined', "did not copy status");
-			ok(typeof xhr.statusText === 'undefined', "did not copy statusText");
-			start();
-		}
-	};
-
-	xhr.open('GET', url);
-	xhr.send();
-});
-
 QUnit.module("XHR Shim");
 
 test("Supports onload", function(){
@@ -1659,16 +1643,15 @@ test("set.Algebra stores provide a count (#58)", function(){
 
 test("abort() sets readyState correctly", function(){
 	stop();
-	fixture('/foo', 1000);
 
 	var xhr = new XMLHttpRequest();
 	xhr.open('GET', '/foo');
 
-	xhr.addEventListener('error', function() {
+	xhr.addEventListener('abort', function() {
 		fixture('/foo', null);
 		ok(true, 'Got to the error handler');
 		equal(xhr.status, "0");
-		equal(xhr.statusText, "aborted");
+		equal(xhr.statusText, "");
 
 		setTimeout(function(){
 			equal(xhr.readyState, 0);

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <title>can-fixture fixture</title>
 <script src="../node_modules/steal/steal.js" main="test/fixture_test"></script>
 <div id="qunit-fixture"></div>

--- a/xhr.js
+++ b/xhr.js
@@ -168,8 +168,18 @@ assign(XMLHttpRequest.prototype,{
 		return "";
 	},
 	abort: function() {
-		// clearTimeout(this.timeoutId);
-		return this._xhr.abort();
+		var xhr = this._xhr;
+
+		// If we are aborting a delayed fixture we have to make the fake
+		// steps that are expected for `abort` to
+		if(this.timeoutId !== undefined) {
+			clearTimeout(this.timeoutId);
+			xhr = makeXHR(this);
+			xhr.open(this.type, this.url, this.async === false ? false : true);
+			xhr.send();
+		}
+
+		return xhr.abort();
 	},
 	// This needs to compile the information necessary to see if
 	// there is a corresponding fixture.
@@ -273,7 +283,7 @@ assign(XMLHttpRequest.prototype,{
 		// At this point there is either not a fixture or a redirect fixture.
 		// Either way we are doing a request.
 		var xhr = makeXHR(this),
-			makeRequest = function(){
+			makeRequest = function() {
 				xhr.open( xhr.type, xhr.url, xhr.async );
 				if(mockXHR._requestHeaders) {
 					Object.keys(mockXHR._requestHeaders).forEach(function(key) {

--- a/xhr.js
+++ b/xhr.js
@@ -19,9 +19,11 @@ var assign = function(dest, source, excluding){
 		if(typeof source.responseType === 'undefined' || source.responseType === '' || source.responseType === 'text') {
 			delete excluding.responseText;
 			delete excluding.responseXML;
+			delete excluding.responseType;
 		} else {
 			excluding.responseText = true;
 			excluding.responseXML = true;
+			excluding.responseType = true;
 		}
 
 		// copy everything on this to the xhr object that is not on `this`'s prototype
@@ -76,7 +78,7 @@ var makeXHR = function(mockXHR){
 
 	// When the real XHR is called back, update all properties
 	// and call all callbacks on the mock XHR.
-	xhr.onreadystatechange = function(ev){
+	xhr.onreadystatechange = function(ev) {
 		if(xhr.readyState <= 1) {
 			if(typeof xhr.status !== 'number') {
 				mockXHR.status = undefined;


### PR DESCRIPTION
This gets can-fixture and its test working in IE 9 and fixes some previous inconsistencies around aborting an XHR.
