### PR TITLE
Making fixture slow-mode test more reliable

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1450,7 +1450,7 @@ if (__dirname !== '/') {
 
 		xhr.addEventListener('load', function(){
 			var delay = new Date() - startTime;
-			ok(delay >= 1000, delay + "ms >= 1000ms delay");
+			ok(delay >= 900, delay + "ms >= 900ms");
 			fixture({url: url}, null);
 			start();
 		});


### PR DESCRIPTION
In IE9, `fixture(..., 1000)` can return in < 1000ms, so this is just checking that it's at least 900ms.

Closes https://github.com/canjs/can-fixture/issues/79.