### PR TITLE
making content-type header less strict

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -969,7 +969,7 @@ if (__dirname !== '/') {
 		xhr.onreadystatechange = function(){
 			if(xhr.readyState === 4) {
 				var header = xhr.getResponseHeader("Content-Type");
-				equal(header, "application/json", "got correct header back");
+				ok(header.indexOf("application/json") >= 0, "got correct header back");
 				start();
 			}
 		};


### PR DESCRIPTION
Closes https://github.com/canjs/can-fixture/issues/86.