### PR TITLE
wrapping mockXHR setter in a try/catch

### DIFF
--- a/xhr.js
+++ b/xhr.js
@@ -260,9 +260,9 @@ each(props, function(prop) {
 			return this._xhr[prop];
 		},
 		set: function(newVal){
-			if(this._xhr[prop] !== newVal) {
+			try {
 				this._xhr[prop] = newVal;
-			}
+			} catch(e) {}
 		}
 	});
 });


### PR DESCRIPTION
Instead of trying to keep track of what properties are settable on the
real XHR object based on the responseType and the readyState and any
other rules that XHRs have in different browsers, this adds a try/catch
around where we try to set properties on the real XHR.

Closes https://github.com/canjs/can-fixture/issues/91.