### PR TITLE
Making getResponseHeader not throw when called onload

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1723,4 +1723,22 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 
 		xhr.send();	
 	});
+
+	asyncTest('should be able to call getResponseHeader onload', function() {
+		fixture('/onload', function(req, res) {
+			res(400);
+		});
+
+		var xhr = new XMLHttpRequest();
+
+		xhr.addEventListener('load', function() {
+			fixture('/onload', null);
+			xhr.getResponseHeader('Set-Cookie');
+			ok(true, 'should not throw when calling getResponseHeader');
+			start();
+		});
+
+		xhr.open('GET', '/onload');
+		xhr.send();
+	});
 }

--- a/xhr.js
+++ b/xhr.js
@@ -168,7 +168,8 @@ assign(XMLHttpRequest.prototype,{
 				mockXHR._xhr = {
 					open: function(){},
 					send: function() {},
-					abort: function(){}
+					abort: function(){},
+					getResponseHeader: function(){}
 				};
 
 				assign(mockXHR, {


### PR DESCRIPTION
Closes https://github.com/canjs/can-fixture/issues/99.