### PR TITLE
Make IDs always unique; fixes #102

### DIFF
--- a/helpers/legacyStore.js
+++ b/helpers/legacyStore.js
@@ -6,10 +6,14 @@ var assign = require("can-util/js/assign/assign");
 
 module.exports = function (count, make, filter) {
 	/*jshint eqeqeq:false */
-	// check
-	// the currentId to use when a new instance is created.
-	var	currentId = 0,
-		items,
+	var getUniqueId = (function () {
+		var i = 0;
+		return function () {
+			return i++;
+		}
+	})();
+
+	var items,
 		findOne = function (id) {
 			for (var i = 0; i < items.length; i++) {
 				if (id == items[i].id) {
@@ -43,9 +47,8 @@ module.exports = function (count, make, filter) {
 				var item = make(i, items);
 
 				if (!item.id) {
-					item.id = i;
+					item.id = getUniqueId();
 				}
-				currentId = Math.max(item.id + 1, currentId + 1) || items.length;
 				items.push(item);
 			}
 		};
@@ -253,7 +256,7 @@ module.exports = function (count, make, filter) {
 			// If an ID wasn't passed into the request, we give the item
 			// a unique ID.
 			if (!item.id) {
-				item.id = currentId++;
+				item.id = getUniqueId();
 			}
 
 			// Push the new item into the store.

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -195,6 +195,36 @@ test('fixture.store fixtures', function () {
 	});
 });
 
+test('fixture.store fixtures should have unique IDs', function () {
+	stop();
+	var store = fixture.store('thing', 100, function (i) {
+		return {name: 'Test ' + i};
+	});
+	fixture('things', store.findAll);
+
+	$.ajax({
+		url: 'things',
+		dataType: 'json',
+		data: {
+			offset: 0,
+			limit: 200,
+			order: ['name ASC'],
+			searchText: 'thing 2'
+		},
+		success: function (result) {
+			debugger;
+			var seenIds = [];
+			var things = result.data;
+			for (var thingKey in things) {
+				var thing = things[thingKey];
+				ok(seenIds.indexOf(thing.id) === -1);
+				seenIds.push(thing.id);
+			}
+			start();
+		}
+	});
+});
+
 test('simulating an error', function () {
 
 	fixture('/foo', function (request, response) {
@@ -1541,7 +1571,7 @@ asyncTest("response headers are set", function(){
 
 	xhr.addEventListener('load', function(){
 		var headers = parseHeaders(xhr.getAllResponseHeaders());
-		
+
 		ok(headers.foo === "bar", "header was set");
 		start();
 	});
@@ -1633,7 +1663,7 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 		setTimeout(function() {
 			xhr.abort();
 		}, 50);
-		
+
 
 		xhr.addEventListener('abort', function() {
 			fixture('/onload', null);
@@ -1721,7 +1751,7 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 			start();
 		});
 
-		xhr.send();	
+		xhr.send();
 	});
 
 	asyncTest('should be able to call getResponseHeader onload', function() {


### PR DESCRIPTION
The `getUniqueId()` cannot be influenced by anything other than its execution and replaces `currentId` to ensure uniqueness.