### PR TITLE
Warn and adapt for METHOD with a store fixture; fixes #30

### DIFF
--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -5,6 +5,7 @@ var set = require("can-set");
 var $ = require("jquery");
 var each = require("can-util/js/each/each");
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
+var canDev = require('can-util/js/dev/dev');
 
 var errorCallback = function(xhr, status, error){
 	ok(false, error);
@@ -600,6 +601,24 @@ test('fixture("METHOD /path", store) should use the right method', function () {
 			start();
 		});
 });
+
+//!steal-remove-start
+test('fixture("METHOD /path", store) should warn when correcting to the right method', function (assert) {
+	assert.expect(1);
+	var store = fixture.store(100, function (i) {
+		return {
+			id: i,
+			name: 'Object ' + i
+		};
+	});
+	var oldWarn = canDev.warn;
+	canDev.warn = function (message) {
+		assert.ok(typeof message === 'string');
+	};
+	fixture('GET /models', store); // <- CHANGE
+	canDev.warn = oldWarn;
+});
+//!steal-remove-end
 
 test('fixture with response callback', 4, function () {
 	fixture.delay = 10;

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -212,7 +212,6 @@ test('fixture.store fixtures should have unique IDs', function () {
 			searchText: 'thing 2'
 		},
 		success: function (result) {
-			debugger;
 			var seenIds = [];
 			var things = result.data;
 			for (var thingKey in things) {
@@ -574,6 +573,30 @@ test('fixture.store can use id of different type (#742)', function () {
 		.then(function (models) {
 			equal(models.data.length, 1, 'Got one model');
 			deepEqual(models.data[0], { id: 2, parentId: 4, name: 'Object 2' });
+			start();
+		});
+});
+
+test('fixture("METHOD /path", store) should use the right method', function () {
+	/*
+		Examples:
+			fixture("GET /path", store) => fixture("GET /path", store.getData)
+			fixture("POST /path", store) => fixture("GET /path", store.createData)
+	*/
+
+	// NOTE: this is a copy-paste of the test case
+	//       "fixture.store can use id of different type (#742)"
+	var store = fixture.store(100, function (i) {
+		return {
+			id: i,
+			name: 'Object ' + i
+		};
+	});
+	fixture('GET /models', store); // <- CHANGE
+	stop();
+	$.ajax({url: "/models", dataType: "json"})
+		.then(function (models) {
+			equal(models.data.length, 100, 'Gotta catch up all!');
 			start();
 		});
 });


### PR DESCRIPTION
Fixes #30 by adding a warning for misuse of `fixture("METHOD /path", store)`.

This includes a test fix (stray `debugger;`) and inference on the `idProp` so if a store does not specify `store.idProp` we can make a logical guess of id name `thing` for `/what/is/the/{thing}`.

<img width="546" alt="screen shot 2017-04-27 at 1 29 42 pm" src="https://cloud.githubusercontent.com/assets/1660953/25496080/a9a23b8a-2b4d-11e7-874d-683a69df267e.png">
