### PR TITLE
Update package.json scripts to include `dist` folder 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "fixture.js",
   "scripts": {
     "preversion": "npm test && npm run build",
-    "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout master && git branch -D release && git push",
+    "version": "git commit -am \"Update version number\" && git checkout -b release && git add -f dist/",
+    "postpublish": "git push --tags && git checkout master && git branch -D release && git push",
     "release:pre": "npm version prerelease && npm publish --tag=pre",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",


### PR DESCRIPTION
Resolves issue #120 

_I think?_

How can I test if this actually works?  `npm pack` still doesn't have the `dist` directory. (which makes sense)... so is there anything that can check it other than a release?