### PR TITLE
check for form data types before processing data #133

### DIFF
--- a/core.js
+++ b/core.js
@@ -27,6 +27,14 @@ var methodMapping = {
 	}
 };
 
+
+// Get a global reference.
+var GLOBAL = typeof global !== "undefined"? global : window;
+
+// valid form types in addition to plain objects as URL search params
+// https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send
+var formTypes = ['ArrayBuffer', 'ArrayBufferView', 'Blob', 'FormData'];
+
 function getMethodAndPath (route) {
 	// Match URL if it has GET, POST, PUT, DELETE or PATCH.
 	var matches = route.match(/(GET|POST|PUT|DELETE|PATCH) (.+)/i);
@@ -249,13 +257,30 @@ exports.get = function(xhrSettings) {
 				};
 			}
 		} else {
-			var xhrData = assign({}, xhrSettings.data || {});
-			fixtureSettings.data = assign(xhrData, data);
+			if(exports.isTypedBody(xhrSettings.data)){
+				fixtureSettings.data = xhrSettings.data;
+			} else {
+				var xhrData = assign({}, xhrSettings.data || {});
+				fixtureSettings.data = assign(xhrData, data);
+			}
 		}
 	}
 
-
 	return fixtureSettings;
+};
+
+exports.isTypedBody = function(data){
+	for(var i = 0; i < formTypes.length; i ++){
+		var Type = GLOBAL[formTypes[i]];
+		if(!Type){
+			continue;
+		}
+		if(data instanceof Type){
+			return true;
+		}
+	}
+
+	return false;
 };
 
 exports.matches = function(settings, fixture, exact) {

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1864,4 +1864,22 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 		xhr.open('GET', '/onload');
 		xhr.send();
 	});
+
+	asyncTest('should not process FormData type #133', function() {
+
+		fixture('/upload', function(req, res) {
+			ok(req.data instanceof FormData, 'data returned should be instance of formdata');
+			res(400);
+		});
+
+		var data = new FormData();
+		var xhr = new XMLHttpRequest();
+		xhr.addEventListener('load', function() {
+			fixture('/upload', null);
+			ok(true, 'should not throw when sending FormData');
+			start();
+		});
+		xhr.open('POST', '/upload', true);
+		xhr.send(data);
+	});
 }


### PR DESCRIPTION
If data passed to xhr.send is a FormData, Blob, or other valid type don't process it into a plain object.