### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/docs/fixture.fixtures.md
+++ b/docs/fixture.fixtures.md
@@ -1,4 +1,5 @@
 @property {Array} can-fixture.fixtures fixtures
+@hide
 
 @signature `fixture.fixtures`
 

--- a/helpers/legacyStore.js
+++ b/helpers/legacyStore.js
@@ -182,6 +182,7 @@ module.exports = function (count, make, filter) {
 		 * @signature `store.findOne(request, response)`
 		 * @param {Object} request Parameters for the request.
 		 * @param {Function} response A function to call with the retrieved item.
+		 * @hide
 		 *
 		 * @body
 		 * `store.findOne(request, response(item))` simulates a request to
@@ -229,6 +230,7 @@ module.exports = function (count, make, filter) {
 		 * @signature `store.destroy(request, callback)`
 		 * @param {Object} request Parameters for the request.
 		 * @param {Function} callback A function to call after destruction.
+		 * @hide
 		 *
 		 * @body
 		 * `store.destroy(request, response())` simulates


### PR DESCRIPTION
Part of https://github.com/canjs/canjs/issues/3660