### PR TITLE
Accept arrays as the request data

### DIFF
--- a/core.js
+++ b/core.js
@@ -4,6 +4,7 @@ var sub = require("can-util/js/string/string").sub;
 var each = require("can-util/js/each/each");
 var assign = require("can-util/js/assign/assign");
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
+var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var canLog = require("can-util/js/log/log");
 var canDev = require("can-util/js/dev/dev");
 require("./store");
@@ -26,14 +27,6 @@ var methodMapping = {
 		'POST': 'createData'
 	}
 };
-
-
-// Get a global reference.
-var GLOBAL = typeof global !== "undefined"? global : window;
-
-// valid form types in addition to plain objects as URL search params
-// https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send
-var formTypes = ['ArrayBuffer', 'ArrayBufferView', 'Blob', 'FormData'];
 
 function getMethodAndPath (route) {
 	// Match URL if it has GET, POST, PUT, DELETE or PATCH.
@@ -256,31 +249,17 @@ exports.get = function(xhrSettings) {
 					throw "fixtures.js Error " + error + " " + message;
 				};
 			}
+
+		} else if (isPlainObject(xhrSettings.data)) {
+			var xhrData = assign({}, xhrSettings.data || {});
+			fixtureSettings.data = assign(xhrData, data);
+
 		} else {
-			if(exports.isTypedBody(xhrSettings.data)){
-				fixtureSettings.data = xhrSettings.data;
-			} else {
-				var xhrData = assign({}, xhrSettings.data || {});
-				fixtureSettings.data = assign(xhrData, data);
-			}
+			fixtureSettings.data = xhrSettings.data;
 		}
 	}
 
 	return fixtureSettings;
-};
-
-exports.isTypedBody = function(data){
-	for(var i = 0; i < formTypes.length; i ++){
-		var Type = GLOBAL[formTypes[i]];
-		if(!Type){
-			continue;
-		}
-		if(data instanceof Type){
-			return true;
-		}
-	}
-
-	return false;
 };
 
 exports.matches = function(settings, fixture, exact) {

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1745,6 +1745,40 @@ test("set.Algebra stores provide a count (#58)", function(){
 	});
 });
 
+asyncTest('should allow Arrays as data type (#133)', function() {
+	fixture('/array-data', function(req, res) {
+		ok(req.data instanceof Array, 'data returned should be instance of Array');
+		return {};
+	});
+
+	var data = [];
+	var xhr = new XMLHttpRequest();
+	xhr.addEventListener('load', function() {
+		fixture('/array-data', null);
+		ok(true, 'should not throw when sending Array');
+		start();
+	});
+	xhr.open('GET', '/array-data');
+	xhr.send(data);
+});
+
+asyncTest('should allow FormData as data type (#133)', function() {
+	fixture('/upload', function(req, res) {
+		ok(req.data instanceof FormData, 'data returned should be instance of formdata');
+		res(400);
+	});
+
+	var data = new FormData();
+	var xhr = new XMLHttpRequest();
+	xhr.addEventListener('load', function() {
+		fixture('/upload', null);
+		ok(true, 'should not throw when sending FormData');
+		start();
+	});
+	xhr.open('POST', '/upload', true);
+	xhr.send(data);
+});
+
 if ("onabort" in XMLHttpRequest._XHR.prototype) {
 	asyncTest('fixture with timeout aborts if xhr timeout less than delay', function() {
 		fixture('/onload', 1000);
@@ -1863,23 +1897,5 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 
 		xhr.open('GET', '/onload');
 		xhr.send();
-	});
-
-	asyncTest('should not process FormData type #133', function() {
-
-		fixture('/upload', function(req, res) {
-			ok(req.data instanceof FormData, 'data returned should be instance of formdata');
-			res(400);
-		});
-
-		var data = new FormData();
-		var xhr = new XMLHttpRequest();
-		xhr.addEventListener('load', function() {
-			fixture('/upload', null);
-			ok(true, 'should not throw when sending FormData');
-			start();
-		});
-		xhr.open('POST', '/upload', true);
-		xhr.send(data);
 	});
 }


### PR DESCRIPTION
This makes it so you can send an array as the data for a request and can-fixture won’t turn it into an object.

Closes https://github.com/canjs/can-fixture/issues/133