### PR TITLE
Make can-fixture work within steal-clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "can-set-legacy": "<2.0.0",
+    "can-test-helpers": "^1.1.2",
     "detect-cyclic-packages": "^1.1.0",
     "jquery": "^3.1.1",
     "jshint": "^2.7.0",

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -6,10 +6,12 @@ var fixture = require("can-fixture");
 var set = require("can-set-legacy");
 var $ = require("jquery");
 var canDev = require('can-log/dev/dev');
+var clone = require("steal-clone");
 var dataFromUrl = require("../data-from-url");
 var canReflect = require("can-reflect");
 var matches = require("../matches");
 var QueryLogic = require("can-query-logic");
+var testHelpers = require("can-test-helpers");
 
 
 var errorCallback = function(xhr, status, error){
@@ -1944,5 +1946,24 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 
 		xhr.open('GET', '/onload');
 		xhr.send();
+	});
+
+	testHelpers.dev.devOnlyTest("Works with steal-clone", function() {
+		clone({})["import"]("can-fixture").then(function(fixture){
+			fixture('/onload', function(req, res) {
+				res(400);
+			});
+
+			var xhr = new XMLHttpRequest();
+			xhr.addEventListener('load', function() {
+				fixture('/onload', null);
+				QUnit.ok(true, "Got to the load event without throwing");
+				start();
+			});
+			xhr.open('GET', '/onload');
+			xhr.send();
+		});
+
+		stop();
 	});
 } // END onabort check

--- a/xhr.js
+++ b/xhr.js
@@ -46,16 +46,25 @@ function callEvents(xhr, ev) {
 	}
 }
 
+function defineNonEnumerable(obj, prop, value) {
+	Object.defineProperty(obj, prop, {
+		enumerable: false,
+		configurable: true,
+		writable: true,
+		value: value
+	});
+}
+
 GLOBAL.XMLHttpRequest = function() {
 	var mockXHR = this;
 	var realXHR = new XHR();
 
 	// store real xhr on mockXHR
-	this._xhr = realXHR;
+	defineNonEnumerable(this, "_xhr", realXHR);
 
 	// create other properties needed by prototype functions
-	this._requestHeaders = {};
-	this.__events = {};
+	defineNonEnumerable(this, "_requestHeaders", {});
+	defineNonEnumerable(this, "__events", {});
 
 	// wire up events to forward from real xhr to fake xhr
 	events.forEach(function(eventName) {


### PR DESCRIPTION
When can-fixture is cloned it's XHR wrapper runs twice. This *should* be
ok, but because our XHR wrapper copies properties from the real XHR, a
loop was being caused because of some properties we add to our wrapper.
Making those properties be non-enumerable prevents the loop from
occuring.