### PR TITLE
support returning promises from dynamic fixtures

### DIFF
--- a/core.js
+++ b/core.js
@@ -213,7 +213,7 @@ exports.callDynamicFixture = function(xhrSettings, fixtureSettings, cb){
 		// fall the fixture
 		var result = fixtureSettings.fixture(xhrSettings, response, xhrSettings.headers, fixtureSettings);
 
-		if (result && typeof result.then === 'function') {
+		if (canReflect.isPromise(result)) {
 			// If we have a promise, wait for it to resolve
 			result.then(function (result) {
 				if (result !== undefined) {

--- a/core.js
+++ b/core.js
@@ -213,9 +213,19 @@ exports.callDynamicFixture = function(xhrSettings, fixtureSettings, cb){
 		// fall the fixture
 		var result = fixtureSettings.fixture(xhrSettings, response, xhrSettings.headers, fixtureSettings);
 
-		if (result !== undefined) {
-			// Resolve with fixture results
-			response(200, result );
+		if (result && typeof result.then === 'function') {
+			// If we have a promise, wait for it to resolve
+			result.then(function (result) {
+				if (result !== undefined) {
+					// Resolve with fixture results
+					response(200, result );
+				}
+			});
+		} else {
+			if (result !== undefined) {
+				// Resolve with fixture results
+				response(200, result );
+			}
 		}
 	};
 

--- a/docs/can-fixture.md
+++ b/docs/can-fixture.md
@@ -36,7 +36,7 @@
   ```
   @codepen
 
-  The requestHandler also supports asynchronous results, by returning a promise or using `async`/`await`. This allows fixtures to depend on each other, introduce dynamic delays, and even depend on external resources.
+  Return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) (or use [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) & [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)) from `requestHandler` to asynchronously return results. This allows fixtures to depend on each other, introduce dynamic delays, and even depend on external resources.
 
   ```js
   import {fixture, ajax} from "can";

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -140,6 +140,26 @@ test('dynamic fixtures', function () {
 		});
 });
 
+test('dynamic fixtures return promises', function () {
+	stop();
+	fixture.delay = 10;
+	fixture('something', function () {
+		return Promise.resolve([{
+			sweet: 'ness'
+		}]);
+	});
+	$.ajax({
+		url: 'something',
+		dataType: 'json'
+	})
+		.done(function (data) {
+			equal(data[0].sweet, 'ness', 'can.get works');
+			start();
+		}).catch(function(err){
+			debugger;
+		});
+});
+
 if (__dirname !== '/') {
 	test('fixture function', 3, function () {
 		stop();
@@ -1832,7 +1852,7 @@ test('fixture returns the old fixture callback when fixtures are removed (#34)',
 		return "foo";
 	};
 	fixture("/services/thing", funcA);
-  
+
 	// in a test, remove default fixture and provide your own
 	var oldFixtures = fixture("/services/thing", null);
 	QUnit.deepEqual(oldFixtures, [{fixture: funcA, url: '/services/thing'}]);

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -135,8 +135,6 @@ test('dynamic fixtures', function () {
 		.done(function (data) {
 			equal(data[0].sweet, 'ness', 'can.get works');
 			start();
-		}).catch(function(err){
-			debugger;
 		});
 });
 
@@ -148,16 +146,14 @@ test('dynamic fixtures return promises', function () {
 			sweet: 'ness'
 		}]);
 	});
+
 	$.ajax({
 		url: 'something',
 		dataType: 'json'
-	})
-		.done(function (data) {
-			equal(data[0].sweet, 'ness', 'can.get works');
-			start();
-		}).catch(function(err){
-			debugger;
-		});
+	}).then(function (data) {
+		equal(data[0].sweet, 'ness', 'can.get works');
+		start();
+	});
 });
 
 if (__dirname !== '/') {


### PR DESCRIPTION
This would allow a lot more flexibility in the use of fixtures, including allowing fixtures to depend on each other, creating route-specific delays, and even allowing resolution from external sources. It would also make it integrate nicely with async/await without adding weight to the library.

```js
fixture('/', async (req, res) => {
  await wait(5000);
  return res({
    foo: 'bar'
  });
});
```