### PR TITLE
#157 adds warning when global fixture is called

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -68,11 +68,9 @@ canReflect.assignMap(fixture, {
 });
 
 if(typeof window !== "undefined" && typeof require.resolve !== "function") {
-	// window.fixture = fixture;
 
 	window.fixture = function(){
-		debugger
-		canDev.warn("You using the global fixture. Make sure you import can-fixture.");
+		canDev.warn("You are using the global fixture. Make sure you import can-fixture.");
 
 		return fixture.apply(this, arguments);
 	};	

--- a/fixture.js
+++ b/fixture.js
@@ -4,6 +4,7 @@ var fixture = core.add;
 var Store = require("./store");
 require("./xhr");
 var canReflect = require("can-reflect");
+var canDev = require("can-log/dev/dev");
 var ns = require("can-namespace");
 // HELPERS START
 
@@ -67,7 +68,14 @@ canReflect.assignMap(fixture, {
 });
 
 if(typeof window !== "undefined" && typeof require.resolve !== "function") {
-	window.fixture = fixture;
+	// window.fixture = fixture;
+
+	window.fixture = function(){
+		debugger
+		canDev.warn("You using the global fixture. Make sure you import can-fixture.");
+
+		return fixture.apply(this, arguments);
+	};	
 }
 
 

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1958,6 +1958,20 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 		xhr.send();
 	});
 
+	testHelpers.dev.devOnlyTest("window.fixture warns when called", function() {
+		var teardown = testHelpers.dev.willWarn(/You are using the global fixture\. Make sure you import can-fixture\./, function(message, matched) {
+			if(matched) {
+				ok(true, "received warning");
+			}
+		});
+
+		window.fixture("GET /api/products", function(){
+			return {};
+		});
+
+		teardown();	
+	});
+
 	testHelpers.dev.devOnlyTest("Works with steal-clone", function() {
 		steal.loader.import("steal-clone", { name: "can-fixture" })
 		.then(function(clone) {
@@ -1983,17 +1997,3 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 
 
 
-testHelpers.dev.devOnlyTest("window.fixture warns when called", function() {
-	debugger
-	var teardown = testHelpers.dev.willWarn(/You using the global fixture\. Make sure you import can-fixture\./, function(message, matched) {
-			if(matched) {
-				ok(true, "received warning");
-			}
-	});
-
-	window.fixture("GET /api/products", function(){
-		return {};
-	});
-
-	teardown();	
-});

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1980,3 +1980,20 @@ if ("onabort" in XMLHttpRequest._XHR.prototype) {
 		stop();
 	});
 } // END onabort check
+
+
+
+testHelpers.dev.devOnlyTest("window.fixture warns when called", function() {
+	debugger
+	var teardown = testHelpers.dev.willWarn(/You using the global fixture\. Make sure you import can-fixture\./, function(message, matched) {
+			if(matched) {
+				ok(true, "received warning");
+			}
+	});
+
+	window.fixture("GET /api/products", function(){
+		return {};
+	});
+
+	teardown();	
+});


### PR DESCRIPTION
For issue #157 adds warning for when global window fixture. But current test not currently running likely due to some other test failing. The test currently added works in isolation but when ran amongst other test it fails.