### PR TITLE
Serialize typed properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "can-reflect": "^1.15.1"
   },
   "devDependencies": {
+    "can-define": "^2.7.18",
     "can-set-legacy": "<2.0.0",
     "can-test-helpers": "^1.1.2",
     "detect-cyclic-packages": "^1.1.0",

--- a/store.js
+++ b/store.js
@@ -94,7 +94,7 @@ function typeConvert(data){
 	var copy = {};
 	canReflect.eachKey(data, function(value, key){
 		if(keys[key]) {
-			copy[key] = canReflect.convert(value, keys[key]);
+			copy[key] = canReflect.serialize(canReflect.convert(value, keys[key]));
 		} else {
 			copy[key] = value;
 		}


### PR DESCRIPTION
When converting a response to a type, if the type has properties that
are themselves typed, we need to serialize those properties so that the
object can be properly serialized to JSON.

Fixes #171