### PR TITLE
Correctly handle createData with string ids

### DIFF
--- a/test/store-test.js
+++ b/test/store-test.js
@@ -111,3 +111,17 @@ QUnit.test("createData, destroyData, updateData", function(assert){
         done();
     });*/
 });
+
+QUnit.test("createData with a string id", function(assert){
+    var store = fixture.store([
+        {id: "helloorld", name: "foo"}
+    ], new QueryLogic({identity: ["id"]}));
+
+    var done = assert.async();
+    store.createData({
+        data: {name: "bar"}
+    }, function(instance){
+        assert.deepEqual(instance, {id: "1", name: "bar"} );
+        done();
+    });
+});


### PR DESCRIPTION
When there is a string id we should use an incrementer starting at `1`
and convert the id to a string before returning from createData.

Closes #173