### PR TITLE
Document additional signatures for fixture.store

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@
 end_of_line = LF
 indent_style = tab
 indent_size = 4
+
+[{*.json,*.yml,*.md}]
+indent_style = space
+indent_size = 2

--- a/docs/fixture.store.md
+++ b/docs/fixture.store.md
@@ -45,6 +45,85 @@
   a restful service layer that supports filtering, pagination, and
   more.  
 
+@signature `fixture.store(baseItems, Type)`
+
+  Create a store that starts with `baseItems` for a service layer for a `Type`.
+
+  ```js
+  import {DefineMap, fixture, ajax} from "can";
+  import {Todo} from "https://unpkg.com/can-demo-models@5";
+
+  // Create a store with initial data.
+  // Pass an empty Array (ex: []) if you want it to be empty.
+  const todoStore = fixture.store( [
+    {
+      id: 1,
+      name: "Do the dishes",
+      complete: true
+    }, {
+      id: 2,
+      name: "Walk the dog",
+      complete: false
+    }
+  ], Todo );
+
+  // Hookup urls to the store:
+  fixture( "/todos/{id}", todoStore );
+
+  ajax( {url: "/todos/1"} ).then( result => {
+    console.log( result );
+  } );
+  ```
+  @codepen
+  @highlight 6-16
+
+  @param {Array} baseItems An array of items that will populate the store.
+  @param {function(){}} Type Any Type with a [can-reflect.getSchema] symbol.
+  @return {can-fixture/StoreType} A store that can be used to simulate
+  a restful service layer that supports filtering, pagination, and
+  more.
+
+@signature `fixture.store(baseItems, schema)`
+
+  Create a store that starts with `baseItems` for a service layer described by [schema can-reflect.getSchema].
+
+  ```js
+  import {DefineMap, fixture, ajax, Reflect} from "can";
+  import {Todo} from "https://unpkg.com/can-demo-models@5";
+
+  // Store the schema, so it can be modified if so desired.
+  const schema = Reflect.getSchema(Todo);
+
+  // Create a store with initial data.
+  // Pass an empty Array (ex: []) if you want it to be empty.
+  const todoStore = fixture.store( [
+    {
+      id: 1,
+      name: "Do the dishes",
+      complete: true
+    }, {
+      id: 2,
+      name: "Walk the dog",
+      complete: false
+    }
+  ], schema );
+
+  // Hookup urls to the store:
+  fixture( "/todos/{id}", todoStore );
+
+  ajax( {url: "/todos/1"} ).then( result => {
+    console.log( result );
+  } );
+  ```
+  @codepen
+  @highlight 9-19
+
+  @param {Array} baseItems An array of items that will populate the store.
+  @param {can-reflect.getSchema} A schema of the keys and identities for this type.
+  @return {can-fixture/StoreType} A store that can be used to simulate
+  a restful service layer that supports filtering, pagination, and
+  more.
+
 @signature `fixture.store(count, makeItems, queryLogic)`
 
   Similar to `fixture.store(baseItems, queryLogic)`, except that
@@ -67,6 +146,87 @@
       complete: fixture.rand( [ true, false ], 1 )[ 0 ]
     } ),
     todoQueryLogic
+  );
+
+  // Hookup urls to the store:
+  fixture( "/todos/{id}", todoStore );
+
+  ajax( {url: "/todos/3"} ).then( result => {
+    console.log( result ); //-> "{'_id':3,'name':'Todo 2','complete':true||false}"
+  } );
+
+  ```
+  @codepen
+  @highlight 9-17
+
+  @param {Number} count The number of `baseItems` to create.
+  @param {function} makeItems A function that will generate `baseItems`
+  @param {can-query-logic} queryLogic A description of the service layer's parameters.
+  @return {can-fixture/StoreType} A store that can be used to simulate
+  a restful service layer that supports filtering, pagination, and
+  more.  
+
+@signature `fixture.store(count, makeItems, Type)`
+
+  Similar to `fixture.store(baseItems, Type)`, except that
+  it uses `makeItems` to create `count` entries in the store.
+
+  ```js
+  import {DefineMap, fixture, ajax} from "can";
+  import {Todo} from "https://unpkg.com/can-demo-models@5";
+  import "//unpkg.com/jquery@3.3.1/dist/jquery.js";
+
+  // Create a store with initial data.
+  const todoStore = fixture.store(
+    1000,
+    ( i ) => ( {
+      id: i + 1,
+      name: "Todo " + i,
+      complete: fixture.rand( [ true, false ], 1 )[ 0 ]
+    } ),
+    Todo
+  );
+
+  // Hookup urls to the store:
+  fixture( "/todos/{id}", todoStore );
+
+  ajax( {url: "/todos/3"} ).then( result => {
+    console.log( result ); //-> "{'_id':3,'name':'Todo 2','complete':true||false}"
+  } );
+
+  ```
+  @codepen
+  @highlight 6-14
+
+  @param {Number} count The number of `baseItems` to create.
+  @param {function} makeItems A function that will generate `baseItems`
+  @param {function(){}} Type A type that implements [can-reflect.getSchema].
+  @return {can-fixture/StoreType} A store that can be used to simulate
+  a restful service layer that supports filtering, pagination, and
+  more.  
+
+@signature `fixture.store(count, makeItems, schema)`
+
+  Similar to `fixture.store(baseItems, schema)`, except that
+  it uses `makeItems` to create `count` entries in the store.
+
+  ```js
+  import {DefineMap, fixture, ajax, Reflect} from "can";
+  import {Todo} from "https://unpkg.com/can-demo-models@5";
+  import "//unpkg.com/jquery@3.3.1/dist/jquery.js";
+
+  // Get the schema, usually in order to modify it.
+  const schema = Reflect.getSchema(Todo);
+
+  // Create a store with initial data.
+  const todoStore = fixture.store(
+    1000,
+    ( i ) => ( {
+      id: i + 1,
+      name: "Todo " + i,
+      complete: fixture.rand( [ true, false ], 1 )[ 0 ]
+    } ),
+    schema
   );
 
   // Hookup urls to the store:

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -2,10 +2,12 @@ var QUnit = require('steal-qunit');
 var fixture = require("can-fixture");
 var QueryLogic = require("can-query-logic");
 var canReflect = require("can-reflect");
-
+var canSymbol = require("can-symbol");
 
 QUnit.module("can-fixture.store");
 
+var newSymbol = canSymbol.for("can.new");
+var isMemberSymbol = canSymbol.for("can.isMember");
 
 QUnit.test("createInstance, destroyInstance, updateInstance", function(assert){
     var store = fixture.store([
@@ -125,3 +127,35 @@ QUnit.test("createData with a string id", function(assert){
         done();
     });
 });
+
+QUnit.test("can take a schema", function(assert) {
+	var schema = {
+		identity: ["id"],
+		keys: {}
+	};
+	var keys = schema.keys;
+
+	keys.id = {};
+	keys.id[newSymbol] = Number;
+	keys.id[isMemberSymbol] = function(value) {
+		return typeof value === "string";
+	};
+
+	keys.name = {};
+	keys.name[newSymbol] = function(value) {
+		return value.toUpperCase();
+	};
+	keys.name[isMemberSymbol] = function() { return false; };
+
+	var store = fixture.store([
+		{id: 1, name: "foo"}
+	], schema);
+
+	var done = assert.async();
+	store.createData({
+		data: {name: "bar"}
+	}, function(instance){
+		assert.deepEqual(instance, {id: 2, name: "BAR"} );
+		done();
+	});
+})


### PR DESCRIPTION
This adds new signatures to the docs to clarify that fixture.store can
take a `Type` or a `schema`.